### PR TITLE
Update kubo version in Dockerfile to v0.42.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 # Install IPFS (Kubo)
-RUN curl -fsSL "https://dist.ipfs.tech/kubo/v0.40.1/kubo_v0.40.1_linux-$(dpkg --print-architecture).tar.gz" | \
+RUN curl -fsSL "https://dist.ipfs.tech/kubo/v0.42.0/kubo_v0.42.0_linux-$(dpkg --print-architecture).tar.gz" | \
   tar -xz -C /tmp && \
   mv /tmp/kubo/ipfs /usr/local/bin/ipfs && \
   rm -rf /tmp/kubo


### PR DESCRIPTION
IPFS has had some updates so I updated the Kubo version.

Tested on my home server that was already running Originless.